### PR TITLE
Rails 5

### DIFF
--- a/carrierwave-activerecord.gemspec
+++ b/carrierwave-activerecord.gemspec
@@ -41,13 +41,13 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
 
   # CarrierWave has broken in 0.x releases.
-  gem.add_runtime_dependency 'carrierwave', '~> 0.8.0'
+  gem.add_runtime_dependency 'carrierwave', '~> 1.0.0'
 
   # ActiveRecord 3.3 is unlikely, but prevent it just in case.
-  gem.add_runtime_dependency 'activerecord', '~> 4.0'
+  gem.add_runtime_dependency 'activerecord', '~> 5.0'
 
-  gem.add_development_dependency 'sqlite3', '~> 1.3'
-  gem.add_development_dependency 'rspec', '~> 2.12'
+  gem.add_development_dependency 'sqlite3', '~> 1.3.0'
+  gem.add_development_dependency 'rspec', '~> 2.12.0'
 
   gem.platform = Gem::Platform::RUBY
   gem.required_ruby_version = '>= 1.9.3'

--- a/carrierwave-activerecord.gemspec
+++ b/carrierwave-activerecord.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
 
   # CarrierWave has broken in 0.x releases.
-  gem.add_runtime_dependency 'carrierwave', '~> 1.0.0'
+  gem.add_runtime_dependency 'carrierwave', '~> 1.0'
 
   # ActiveRecord 3.3 is unlikely, but prevent it just in case.
   gem.add_runtime_dependency 'activerecord', '~> 5.0'

--- a/lib/carrierwave-activerecord/storage/active_record_file.rb
+++ b/lib/carrierwave-activerecord/storage/active_record_file.rb
@@ -8,12 +8,6 @@ module CarrierWave
 
         alias_method    :delete, :destroy
         alias_attribute :read, :data
-
-        attr_accessible :identifier,
-                        :original_filename,
-                        :content_type,
-                        :size,
-                        :data
       end # ActiveRecordFile
 
     end # ActiveRecord

--- a/lib/carrierwave-activerecord/storage/version.rb
+++ b/lib/carrierwave-activerecord/storage/version.rb
@@ -1,7 +1,7 @@
 module CarrierWave
   module Storage
     module ActiveRecord
-      VERSION = '0.1.0rc6'
+      VERSION = '0.3.0'
     end
   end
 end


### PR DESCRIPTION
Code changes were pulled in from [a PR on the original base of our fork](https://github.com/richardkmichael/carrierwave-activerecord/pull/35) but has been stagnant since March.