### PR TITLE
Relax activerecord gemspec constraint to allow for Rails 6

### DIFF
--- a/carrierwave-activerecord.gemspec
+++ b/carrierwave-activerecord.gemspec
@@ -43,8 +43,7 @@ Gem::Specification.new do |gem|
   # CarrierWave has broken in 0.x releases.
   gem.add_runtime_dependency 'carrierwave', '~> 1.0'
 
-  # ActiveRecord 3.3 is unlikely, but prevent it just in case.
-  gem.add_runtime_dependency 'activerecord', '~> 5.0'
+  gem.add_runtime_dependency 'activerecord', '>= 5.0'
 
   gem.add_development_dependency 'sqlite3', '~> 1.3.0'
   gem.add_development_dependency 'rspec', '~> 2.12.0'


### PR DESCRIPTION
Rails 6 has been deployed and working with this branch for over 3 months. There has not been any issues with uploading and storing files using this repo as-is.